### PR TITLE
relax numpy requirement, bump stackstac min version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,12 @@ setup(
     package_data={"cubo": ["data/*.json"]},
     install_requires=[
         "dask>=2023.7.0",
-        "numpy<2.0.0",
+        "numpy",
         "pandas>=2.0.3",        
         "planetary_computer>=1.0.0",
         "pystac_client>=0.7.2",
         "scipy>=1.12.0",
-        "stackstac>=0.4.4",
+        "stackstac>=0.5.1",
         "xarray>=2023.6.0",
     ],
     extras_require={


### PR DESCRIPTION
Hi @davemlz,

hope you're well! I noticed that version [2024.6.0](https://github.com/ESDS-Leipzig/cubo/releases/tag/2024.6.0) of `cubo` pinned `numpy<2.0.0`. However,  `stackstac` is supporting `numpy>2.0.0`  since version [0.5.1 (2024-08-09)](https://github.com/gjoseph92/stackstac/blob/main/CHANGELOG.md#051-2024-08-09). 

It would be great  to relax the NumPy requirement and release an update of  `cubo`. I also bumped the minimum version requirement of `stackstac` in order to avoid any clashes between `stackstac<0.5.1` and `numpy>2.0.0`. 

Let me know what you think! I also did a quick test of course and everything worked fine. 